### PR TITLE
docs: refine Lynk SQL & metric guidance, document entity-list scoping

### DIFF
--- a/concepts/metrics.md
+++ b/concepts/metrics.md
@@ -56,7 +56,7 @@ Dialect-specific constructs pass through if your warehouse supports them:
 - `PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY {net_amount})` — most modern warehouses.
 - `IFF(...)`, `APPROX_PERCENTILE(...)` — Snowflake.
 
-Window functions are not supported inside a metric definition's `sql:`. They are supported in queries — see [Lynk SQL](../api/lynk-sql.md).
+Window functions are not supported inside a metric definition's `sql:`. They **are** supported in `formula` feature `sql:` (a window produces a per-row value, which is what a formula is) and in queries — see [Lynk SQL](../api/lynk-sql.md) and the [formula section of the entity YAML reference](../file-types/entity-yaml.md#formula--derived-value).
 
 ---
 

--- a/file-types/entity-yaml.md
+++ b/file-types/entity-yaml.md
@@ -28,8 +28,8 @@ name: {entity_name}
 description: {one or two sentence description}
 
 key_source: {warehouse_table}    # primary table — defines entity identity
-keys:                            # fields that uniquely identify a row
-  - {field_name}
+keys:                            # FEATURE names (not raw columns) that uniquely identify a row
+  - {feature_name}
 
 features:                        # attributes — see Feature Types below
   - ...
@@ -50,11 +50,15 @@ examples:                        # entity-level query examples
 | `name` | Yes | Entity identifier — referenced in queries as `FROM <name>` |
 | `description` | Yes | Human-readable summary for agent context |
 | `key_source` | Yes | The primary warehouse table (schema.db.table format) |
-| `keys` | Yes | List of fields that form the primary key |
+| `keys` | Yes | List of **feature names** (not raw column names) that form the primary key. Each entry must match the `name:` of a feature in `features:`. |
 | `features` | Yes | List of feature definitions |
 | `metrics` | No | List of entity metric definitions |
 | `related_sources` | No | Secondary tables for enrichment |
 | `examples` | No | Entity-scoped query examples |
+
+{% hint style="warning" %}
+**`keys` must reference feature names, not raw columns.** Each entry in `keys:` is the `name:` of a feature in `features:` — e.g. `vertical`, not the warehouse column `VERTICAL`. If a key lists a raw column that also has a feature of the same name, the generated SQL projects the column twice and fails at query time with `ambiguous column name`. (So every key column needs a feature, and the key lists that feature's name.)
+{% endhint %}
 
 ---
 
@@ -165,6 +169,10 @@ Declare the `related_source` or the entity relationship before defining the fiel
 | `join_name` | Which join to use. For a `related_source` table, the join defined on that source; for an entity source, a named join on the relationship. Omit (or set `null`) to use the default. |
 | `filters` | Pre-filters applied to the source before retrieving the field. Omit if no filters. |
 
+{% hint style="warning" %}
+**Quote reserved-word source columns.** If a source column's name is a SQL reserved word (e.g. `ORDER`, `ROW`, `VALUE`), quote it in `field:` — `field: '"ORDER"'`. Column identifiers are passed through to the warehouse without auto-quoting, so an unquoted reserved word produces a SQL compile error at query time (which `validate` does not catch).
+{% endhint %}
+
 ---
 
 ### `metric` — Aggregated Value from a Related Entity
@@ -239,6 +247,16 @@ Computes a value from other features on the same entity. References other featur
 ```
 
 Formula features can reference any feature on the same entity — `field`, `first_last`, `formula`, or `metric`. They cannot reference features on other entities.
+
+**Window functions are allowed in a formula's `sql:`.** `ROW_NUMBER()`, `RANK()`, `LAG()`, `OVER (PARTITION BY … ORDER BY …)`, etc. each produce a per-row value, which is exactly what a formula computes — so they belong here. (They are **not** allowed in a *metric*'s `sql:`; see [Metrics](../concepts/metrics.md).) For example, an `order_sequence` formula can rank rows within a group:
+
+```yaml
+- type: formula
+  name: order_sequence
+  data_type: number
+  description: Sequence of this order among the customer's orders (first = 1)
+  sql: ROW_NUMBER() OVER (PARTITION BY {customer_id} ORDER BY {order_date} ASC)
+```
 
 ---
 

--- a/file-types/knowledge-md.md
+++ b/file-types/knowledge-md.md
@@ -10,7 +10,7 @@ Knowledge files teach the agent what things mean — definitions, business rules
 ---
 type: knowledge
 domain: "default"        # required — "*", a domain name, or a list of domain names
-entity: customer         # optional — omit for domain-wide knowledge
+entity: customer         # optional — a single entity, or a list [a, b, c]; omit for domain-wide knowledge
 ---
 ```
 
@@ -18,7 +18,7 @@ entity: customer         # optional — omit for domain-wide knowledge
 |---|---|---|
 | `type` | `knowledge` | Identifies this as a knowledge file |
 | `domain` | `"*"`, `"default"`, `"marketing"`, or a list | Which domain(s) this file applies to |
-| `entity` | entity name | Scopes to a specific entity. Omit for domain-wide files. |
+| `entity` | entity name, or a list of names (`[a, b, c]`) | Scopes to a specific entity — or, with a list, to a set of entities (loads when **any** is queried). Omit for domain-wide files. |
 
 ---
 
@@ -31,6 +31,7 @@ Knowledge files are scoped by domain and optionally by entity — context compou
 | Business (company-wide) | `domain: "*"` | Every query in every domain |
 | Domain | `domain: "{domain}"` (e.g. `"default"`, `"marketing"`) | Every query in that domain |
 | Entity | `domain: "{domain}"` + `entity: {entity}` | Every query involving that entity in that domain |
+| Entity set | `domain: "{domain}"` + `entity: [a, b, c]` | Every query involving **any** of the listed entities in that domain — for context shared by several entities, without per-entity duplication |
 
 For the full inheritance model and override rules, see the [Domains reference](../concepts/domains.md).
 

--- a/file-types/task-instructions-md.md
+++ b/file-types/task-instructions-md.md
@@ -11,7 +11,7 @@ Task instruction files tell the agent how to execute a specific task — SQL pat
 type: task-instructions
 domain: "default"        # or "*" for all domains
 tasks: "text-to-sql"     # which task this applies to
-entity: customer         # optional — omit for domain-wide instructions
+entity: customer         # optional — a single entity, or a list [a, b, c]; omit for domain-wide instructions
 ---
 ```
 
@@ -20,7 +20,7 @@ entity: customer         # optional — omit for domain-wide instructions
 | `type` | `task-instructions` | Note: hyphen, not underscore |
 | `domain` | `"*"`, `"default"`, `"marketing"`, etc. | Which domain this applies to |
 | `tasks` | `"text-to-sql"` | Which task this file applies to |
-| `entity` | entity name | Optional. Scopes to a specific entity. Omit for domain-wide instructions. |
+| `entity` | entity name, or a list of names (`[a, b, c]`) | Optional. Scopes to a specific entity — or, with a list, to a set of entities (loads when **any** is queried). Omit for domain-wide instructions. |
 
 ---
 
@@ -33,6 +33,7 @@ Task instructions scope by domain and optionally by entity, just like knowledge 
 | All entities in all domains | `domain: "*"` / `tasks: "text-to-sql"` | Any text-to-sql task |
 | All entities in one domain | `domain: "default"` / `tasks: "text-to-sql"` | Any text-to-sql task in this domain |
 | Specific entity | `domain: "default"` / `entity: customer` / `tasks: "text-to-sql"` | text-to-sql on the `customer` entity |
+| A set of entities | `domain: "default"` / `entity: [a, b, c]` / `tasks: "text-to-sql"` | text-to-sql on **any** of the listed entities — for SQL rules shared by several entities, without per-entity duplication |
 
 ---
 


### PR DESCRIPTION
  ## What & why

  Refines the docs around Lynk SQL, metrics, and entity modeling — consolidating
  duplicated guidance into single sources of truth and documenting behavior that
  was previously undocumented or unclear.

  ## Changes

  - **Lynk SQL syntax migration** — migrate docs to the new Lynk SQL syntax and
    expand the documented engine capabilities; clarify syntax rules and where
    domain knowledge belongs.
  - **Single sources of truth** — consolidate SQL and metric guidance so each
    topic lives in one place; metric content now lives in `concepts/metrics.md`,
    with residual duplication removed.
  - **Entity-list scoping** — `knowledge` and `task-instructions` files now
    document that the `entity` frontmatter accepts a list `[a, b, c]`, scoping a
    file to a set of entities (loads when **any** is queried). Confirmed at runtime.
  - **Entity-YAML corrections:**
    - Window functions are allowed in a `formula`'s `sql:` (per-row value) — and
      are **not** allowed in a metric's `sql:`.
    - Quote reserved-word source columns in `field:` (e.g. `field: '"ORDER"'`);
      identifiers pass through to the warehouse un-quoted.
    - `keys` must reference **feature names**, not raw warehouse columns.
  - Address earlier PR review feedback.

  ## Notes

  - Docs only — no code or tooling changes.
  - All examples use generic/canonical placeholders; no customer identifiers.